### PR TITLE
API can provide products sorted in categories

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,3 +1,4 @@
 class Product < ApplicationRecord
   validates_presence_of :name, :description, :price
+enum category: [:starters, :maincourses, :desserts, :drinks]
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,4 @@
 class Product < ApplicationRecord
   validates_presence_of :name, :description, :price, :category
-  enum category: [:starters, :maincourses, :desserts, :drinks]
+  enum category: [:starters, :main_courses, :desserts, :drinks]
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,4 @@
 class Product < ApplicationRecord
-  validates_presence_of :name, :description, :price
-enum category: [:starters, :maincourses, :desserts, :drinks]
+  validates_presence_of :name, :description, :price, :category
+  enum category: [:starters, :maincourses, :desserts, :drinks]
 end

--- a/db/migrate/20200708114313_add_category_to_products.rb
+++ b/db/migrate/20200708114313_add_category_to_products.rb
@@ -1,0 +1,5 @@
+class AddCategoryToProducts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :products, :category, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_07_084945) do
+ActiveRecord::Schema.define(version: 2020_07_08_114313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2020_07_07_084945) do
     t.integer "price"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "category"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,4 +6,4 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-products = Product.create([{ rname: 'Pokebowl', description: 'fresh', price: 150 }, { name: 'Burger', description: 'juicy', price: 125 }])
+products = Product.create([{ name: 'Pokebowl', description: 'fresh', price: 150 }, { name: 'Burger', description: 'juicy', price: 125 }])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,1 @@
-products = Product.create([{ name: 'Pokebowl', description: 'fresh', price: 150, category: 'maincourses' }, { name: 'Burger', description: 'juicy', price: 125, category: 'maincourses' }, { name: 'Juice', description: 'sweet', price: 30, category: 3 }])
+products = Product.create([{ name: 'Pokebowl', description: 'fresh', price: 150, category: 'main_courses' }, { name: 'Burger', description: 'juicy', price: 125, category: 'main_courses' }, { name: 'Juice', description: 'sweet', price: 30, category: 'drinks' }])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,1 @@
-products = Product.create([{ name: 'Pokebowl', description: 'fresh', price: 150 }, { name: 'Burger', description: 'juicy', price: 125 }])
+products = Product.create([{ name: 'Pokebowl', description: 'fresh', price: 150, category: 'maincourses' }, { name: 'Burger', description: 'juicy', price: 125, category: 'maincourses' }, { name: 'Juice', description: 'sweet', price: 30, category: 3 }])

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     name { "MyString" }
     description { "MyText" }
     price { 1 }
-    category{1}
+    category{ 1 }
   end
 end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     name { "MyString" }
     description { "MyText" }
     price { 1 }
+    category{1}
   end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -10,11 +10,13 @@ RSpec.describe Product, type: :model do
     it { is_expected.to have_db_column :name }
     it { is_expected.to have_db_column :description }
     it { is_expected.to have_db_column :price }
+    it { is_expected.to have_db_column :category }
   end
 
   describe 'Validations' do
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_presence_of :description }
     it { is_expected.to validate_presence_of :price }
+    it { is_expected.to validate_presence_of :category }
   end
 end

--- a/spec/requests/api/v1/product_spec.rb
+++ b/spec/requests/api/v1/product_spec.rb
@@ -11,8 +11,13 @@ RSpec.describe 'GET /v1/products', type: :request do
       expect(response).to have_http_status 200
     end
 
-    it'should return product' do
+    it 'should return product' do
       expect(response_json['products'].count).to eq 3
+    end
+    
+    it 'products should have categories' do
+      product = Product.last
+      expect(product.category).to eq 'maincourses'
     end
   end
 

--- a/spec/requests/api/v1/product_spec.rb
+++ b/spec/requests/api/v1/product_spec.rb
@@ -16,8 +16,7 @@ RSpec.describe 'GET /v1/products', type: :request do
     end
     
     it 'products should have categories' do
-      product = Product.last
-      expect(product.category).to eq 'maincourses'
+      expect(response_json['products'].first['category']).to eq "main_courses"
     end
   end
 


### PR DESCRIPTION
## [PT board URL]( https://www.pivotaltracker.com/story/show/173654956)
### User Story
```
As a restaurant API
In order to give the client better sorted products
I would like to be able to send off the products with their category listed
```
## Changes proposed in this pull request:
Add category atribute to the product model(enum).
Added test for the index endpoint to ensure it returns the products category
* 
## What I have learned working on this feature:
we learned how to retrieve the date of attributes from the rails c
we learned how to use the enum with attributes.
we learned how to test the enum attributes.
* 

