### PR TITLE
API provides functionality for user to see their current order

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.7'
 gem 'rack-cors', require: 'rack/cors'
 gem 'devise_token_auth'
+gem 'active_model_serializers'
 
 group :development, :test do
   gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.10)
+      actionpack (>= 4.1, < 6.1)
+      activemodel (>= 4.1, < 6.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.0.3.2)
       activesupport (= 6.0.3.2)
       globalid (>= 0.3.6)
@@ -61,6 +66,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
     coveralls (0.8.23)
@@ -95,6 +102,7 @@ GEM
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     json (2.3.1)
+    jsonapi-renderer (0.2.2)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -218,6 +226,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   bootsnap (>= 1.2)
   coveralls
   devise_token_auth

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -6,12 +6,12 @@ class Api::V1::OrdersController < ApplicationController
   end
 
   def update
-
     order = current_user.orders.find(params[:id])
     product = Product.find(params[:product_id])
     order.order_items.create(product: product)
     render json: create_json_response(order)
   end
+
   private
   def create_json_response(order)
     json = { order: OrderSerializer.new(order) }

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -2,14 +2,19 @@ class Api::V1::OrdersController < ApplicationController
   def create
     order = Order.create(user: current_user)
     order.order_items.create(product_id: params[:product_id])
-    render json: { message: 'The product has been added to your order', order_id: order.id }
+    render json: create_json_response(order)
   end
 
   def update
 
-    order = Order.find(params[:id])
+    order = current_user.orders.find(params[:id])
     product = Product.find(params[:product_id])
     order.order_items.create(product: product)
-    render json: { message: 'The product has been added to your order', order_id: order.id }
+    render json: create_json_response(order)
+  end
+  private
+  def create_json_response(order)
+    json = { order: OrderSerializer.new(order) }
+    json.merge!(message: "The product has been added to your order" )
   end
 end

--- a/app/serializers/order_serializer.rb
+++ b/app/serializers/order_serializer.rb
@@ -1,6 +1,13 @@
 class OrderSerializer < ActiveModel::Serializer
   attributes :id, :total, :products 
+  def products
+    object.order_items.group_by(&:product_id).map do |key, value|
+      product = value.first.product
+      { amount: value.size, name: product.name, total: (value.size * product.price) }
+    end
+  end
+
   def total
-    binding.pry 
+    object.order_items.joins(:product).sum('products.price')
   end
 end

--- a/app/serializers/order_serializer.rb
+++ b/app/serializers/order_serializer.rb
@@ -1,0 +1,6 @@
+class OrderSerializer < ActiveModel::Serializer
+  attributes :id, :total, :products 
+  def total
+    binding.pry 
+  end
+end

--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -1,0 +1,1 @@
+ActiveModelSerializers.config.adapter = :json

--- a/spec/requests/api/v1/user_can_create_new_order_spec.rb
+++ b/spec/requests/api/v1/user_can_create_new_order_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'POST /api/v1/orders', type: :request do
-  let!(:product) { create(:product, name: 'Pokebowl') }
+  let!(:product) { create(:product, name: 'Pokebowl', price: 30) }
   let(:user) { create(:user) }
   let(:credentials) { user.create_new_auth_token }
   let(:user_headers) { { HTTP_ACCEPT: 'application/json'}.merge!(credentials) }
@@ -18,6 +18,12 @@ RSpec.describe 'POST /api/v1/orders', type: :request do
     end
     it 'responds with order_id ' do 
       expect(response_json['order_id']).to eq Order.last.id
+    end
+    it "responds with the right amount of products currently in the order" do
+      expect(response_json['order']['products'].count).to eq 1
+    end
+    it "responds with current order total" do
+      expect(response_json['order']['total']).to eq 30
     end
   end
 end  

--- a/spec/requests/api/v1/user_can_create_new_order_spec.rb
+++ b/spec/requests/api/v1/user_can_create_new_order_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'POST /api/v1/orders', type: :request do
       expect(response_json['message']).to eq 'The product has been added to your order'
     end
     it 'responds with order_id ' do 
-      expect(response_json['order_id']).to eq Order.last.id
+      expect(response_json['order']['id']).to eq Order.last.id
     end
     it "responds with the right amount of products currently in the order" do
       expect(response_json['order']['products'].count).to eq 1

--- a/spec/requests/api/v1/user_can_create_new_order_spec.rb
+++ b/spec/requests/api/v1/user_can_create_new_order_spec.rb
@@ -10,18 +10,23 @@ RSpec.describe 'POST /api/v1/orders', type: :request do
       params: { product_id: product.id },
       headers: user_headers
     end
+    
     it ' responds with 200 status' do
       expect(response.status).to eq 200
     end
+
     it 'responds with success message' do
       expect(response_json['message']).to eq 'The product has been added to your order'
     end
+
     it 'responds with order_id ' do 
       expect(response_json['order']['id']).to eq Order.last.id
     end
+
     it "responds with the right amount of products currently in the order" do
       expect(response_json['order']['products'].count).to eq 1
     end
+
     it "responds with current order total" do
       expect(response_json['order']['total']).to eq 30
     end

--- a/spec/requests/api/v1/user_can_update_order_spec.rb
+++ b/spec/requests/api/v1/user_can_update_order_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe 'PUT /api/v1/orders', type: :request do
     let!(:pizza) { create(:product, name: 'Pizza', price: 50) }
+    let!(:falafel) { create(:product, name: 'Falafel', price: 60) }
     let!(:mushrooms) { create(:product, name: 'Swamp', price: 3) }
 
     let(:user) { create(:user) }
@@ -7,15 +8,15 @@ RSpec.describe 'PUT /api/v1/orders', type: :request do
     let(:user_headers) { { HTTP_ACCEPT: 'application/json'}.merge!(credentials) }
 
     let(:order) { create(:order, user: user) }
-    let!(:order_item) { create(:order_item, product: pizza, order: order) }
+    let!(:order_item) { 3.times{create(:order_item, product: pizza, order: order) } }
+    let!(:more_order_item) { 5.times{create(:order_item, product: falafel, order: order) } }
 
-  
     describe 'successfully' do
-        before do 
+      before do 
         put "/api/v1/orders/#{order.id}",
         params: { product_id: mushrooms.id },
         headers: user_headers
-       end
+      end
 
       it 'responds with 200 status' do
         expect(response.status).to eq 200
@@ -26,16 +27,15 @@ RSpec.describe 'PUT /api/v1/orders', type: :request do
       end
 
       it 'responds with order_id ' do 
-        expect(response_json['order_id']).to eq Order.last.id
+        expect(response_json['order']['id']).to eq order.id
       end
 
       it "responds with the right amount of products currently in the order" do
-        expect(response_json['order']['products'].count).to eq 2
+        expect(response_json['order']['products'].count).to eq 3
       end
     
       it "responds with current order total" do
-        expect(response_json['order']['total']).to eq 53
+        expect(response_json['order']['total']).to eq 453
       end
-  
   end
 end

--- a/spec/requests/api/v1/user_can_update_order_spec.rb
+++ b/spec/requests/api/v1/user_can_update_order_spec.rb
@@ -29,8 +29,13 @@ RSpec.describe 'PUT /api/v1/orders', type: :request do
         expect(response_json['order_id']).to eq Order.last.id
       end
 
-      it 'adds another product to the order' do
-        expect(order.order_items.count).to eq 2
+      it "responds with the right amount of products currently in the order" do
+        expect(response_json['order']['products'].count).to eq 2
       end
-    end
+    
+      it "responds with current order total" do
+        expect(response_json['order']['total']).to eq 53
+      end
+  
+  end
 end


### PR DESCRIPTION
## [PT board URL]( https://www.pivotaltracker.com/story/show/173654953 )
### User Story
```
As a restaurant API
In order to give the user a way to see their current order
I would like to make sure to open up a endpoint for that and make sure that a user can only have one current order
```
## Changes proposed in this pull request:
* Generate serializer controller
* Modify create and updated spec
* Define method to add total price of order

## What I have learned working on this feature:
* We learned how to use serializer


## Packages/Gems added
- Serializer